### PR TITLE
Namespaced function support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package enables [__WebAssembly__](https://webassembly.org/) for [__React Na
    - [__Android__](https://reactnative.dev/docs/new-architecture-library-android)
    - At the time of writing, the new architecture is [__not yet enabled__](https://reactnative.dev/docs/next/the-new-architecture/use-app-template#development-environment) for [__Expo__](https://expo.io).
 2. Install `react-native-webassembly`:
-   
+
    ```shell
    yarn add react-native-webassembly
    ```
@@ -71,7 +71,12 @@ const module = await WebAssembly.instantiate<{
   getFieldNumLen32: () => number;
   // ...
 }>(bufferSource, {
-  imports: {
+  // Declare custom memory implementation.
+  env: {
+    memory: new WebAssembly.Memory({ initial: 32767 }),
+  },
+  // Define the scope of the import functions.
+  runtime: {
     exceptionHandler: (value: number) => console.error(value),
   },
 });

--- a/android/cpp-adapter.cpp
+++ b/android/cpp-adapter.cpp
@@ -12,7 +12,8 @@ Java_com_webassembly_WebassemblyModule_nativeInstantiate(
   jbyteArray bufferSource,
   jlong bufferSourceLength,
   jdouble stackSizeInBytes,
-  jobjectArray rawFunctions
+  jobjectArray rawFunctions,
+  jobjectArray rawFunctionScopes
 ) {
 
   std::string iid_str = std::string(env->GetStringUTFChars(iid, NULL));
@@ -28,12 +29,21 @@ Java_com_webassembly_WebassemblyModule_nativeInstantiate(
     rawFunctionsVec.push_back(std::string(rawString));
   }
 
+  std::vector<std::string> rawFunctionScopesVec;
+
+  for (jsize i = 0; i < env->GetArrayLength(rawFunctionScopes); i++) {
+    jstring str = (jstring) env->GetObjectArrayElement(rawFunctionScopes, i);
+    const char* rawString = env->GetStringUTFChars(str, 0);
+    rawFunctionScopesVec.push_back(std::string(rawString));
+  }
+
   RNWebassemblyInstantiateParams params = {
     iid_str,
     uint8Buffer,
     static_cast<size_t>(bufferSourceLength),
     static_cast<double>(stackSizeInBytes),
-    &rawFunctionsVec
+    &rawFunctionsVec,
+    &rawFunctionScopesVec,
   };
 
   return webassembly::instantiate(&params);

--- a/android/src/main/java/com/webassembly/WebassemblyModule.java
+++ b/android/src/main/java/com/webassembly/WebassemblyModule.java
@@ -31,7 +31,14 @@ public class WebassemblyModule extends NativeWebassemblySpec {
     System.loadLibrary("cpp");
   }
 
-  private static native double nativeInstantiate(String iid, byte[] bufferSource, long bufferSourceLength, double stackSizeInBytes, String[] rawFunctions);
+  private static native double nativeInstantiate(
+    String iid,
+    byte[] bufferSource,
+    long bufferSourceLength,
+    double stackSizeInBytes,
+    String[] rawFunctions,
+    String[] rawFunctionScopes
+  );
 
   private static native double nativeInvoke(String iid, String func, String[] args, ArrayList<String> result);
 
@@ -39,12 +46,16 @@ public class WebassemblyModule extends NativeWebassemblySpec {
     final String iid = pParams.getString("iid");
     final String bufferSource = pParams.getString("bufferSource");
     final int stackSizeInBytes = pParams.getInt("stackSizeInBytes");
+
     final ReadableArray rawFunctionsArray = pParams.getArray("rawFunctions");
+    final ReadableArray rawFunctionScopesArray = pParams.getArray("rawFunctionScopes");
 
     final String[] rawFunctions = new String[rawFunctionsArray.size()];
+    final String[] rawFunctionScopes = new String[rawFunctionScopesArray.size()];
 
     for (int i = 0; i < rawFunctionsArray.size(); i += 1) {
       rawFunctions[i] = rawFunctionsArray.getString(i);
+      rawFunctionScopes[i] = rawFunctionScopesArray.getString(i);
     }
 
     final byte[] bufferSourceBytes = Base64.decode(bufferSource, Base64.DEFAULT);
@@ -54,7 +65,8 @@ public class WebassemblyModule extends NativeWebassemblySpec {
       bufferSourceBytes,
       bufferSourceBytes.length,
       stackSizeInBytes,
-      rawFunctions
+      rawFunctions,
+      rawFunctionScopes
     );
   }
 

--- a/cpp/react-native-webassembly.cpp
+++ b/cpp/react-native-webassembly.cpp
@@ -48,10 +48,12 @@ namespace webassembly {
       runtime.load(mod);
 
       std::vector<std::string>::value_type *rawFunctions = a->rawFunctions->data();
+      std::vector<std::string>::value_type *rawFunctionScopes = a->rawFunctionScopes->data();
 
       for (int i = 0; i < a->rawFunctions->size(); ++i) {
         std::string name = rawFunctions[i];
-
+        std::string scope = rawFunctionScopes[i];
+        
         /* TODO: These require implementation. */
 
         /* v(i) */
@@ -65,8 +67,8 @@ namespace webassembly {
         };
 
         // HACK: How to propagate instantiation back to runtime?
-        try { mod.link("*", name.data(), v_i);  continue; } catch (wasm3::error &e) {}
-        try { mod.link("*", name.data(), v_ii); continue; } catch (wasm3::error &e) {}
+        try { mod.link(scope.data(), name.data(), v_i);  continue; } catch (wasm3::error &e) {}
+        try { mod.link(scope.data(), name.data(), v_ii); continue; } catch (wasm3::error &e) {}
 
         throw std::runtime_error(std::string("Unsupported signature for " + name + "."));
       }

--- a/cpp/react-native-webassembly.cpp
+++ b/cpp/react-native-webassembly.cpp
@@ -65,8 +65,6 @@ namespace webassembly {
         t_v_ii v_ii = [](int32_t p, int32_t q) {
           throw std::runtime_error(std::string("v(ii)"));
         };
-          
-        std::cout << "scope is " << scope.data() << std::endl;
 
         // HACK: How to propagate instantiation back to runtime?
         try { mod.link(scope.data(), name.data(), v_i);  continue; } catch (wasm3::error &e) {}

--- a/cpp/react-native-webassembly.cpp
+++ b/cpp/react-native-webassembly.cpp
@@ -65,6 +65,8 @@ namespace webassembly {
         t_v_ii v_ii = [](int32_t p, int32_t q) {
           throw std::runtime_error(std::string("v(ii)"));
         };
+          
+        std::cout << "scope is " << scope.data() << std::endl;
 
         // HACK: How to propagate instantiation back to runtime?
         try { mod.link(scope.data(), name.data(), v_i);  continue; } catch (wasm3::error &e) {}

--- a/cpp/react-native-webassembly.h
+++ b/cpp/react-native-webassembly.h
@@ -12,6 +12,7 @@ struct RNWebassemblyInstantiateParams {
   double      stackSizeInBytes;
     
   std::vector<std::string>* rawFunctions;
+  std::vector<std::string>* rawFunctionScopes;
 };
 
 struct RNWebassemblyInvokeParams {

--- a/example/src/hooks/useWasmCircomRuntime.ts
+++ b/example/src/hooks/useWasmCircomRuntime.ts
@@ -126,7 +126,7 @@ export function useWasmCircomRuntime() {
           // https://github.com/iden3/circom_runtime/blob/f9de6f7d6efe521b5df6775258779ec9032b5830/js/witness_calculator.js#L27
           memory: new WebAssembly.Memory({ initial: 32767 }),
         },
-        imports: {
+        runtime: {
           exceptionHandler(value: number) {
             console.warn('got exception', value);
           },

--- a/ios/Webassembly.mm
+++ b/ios/Webassembly.mm
@@ -13,7 +13,12 @@ RCT_EXPORT_MODULE()
     for (const auto& rawFunction : a.rawFunctions())
       rawFunctions.push_back([rawFunction UTF8String]);
     
-    return @(webassembly::instantiate(new RNWebassemblyInstantiateParams{[a.iid() UTF8String], bufferSource, (size_t)data.length, a.stackSizeInBytes(), &rawFunctions}));
+    std::vector<std::string> rawFunctionScopes;
+    
+    for (const auto& rawFunctionScope : a.rawFunctionScopes())
+      rawFunctionScopes.push_back([rawFunctionScope UTF8String]);
+    
+    return @(webassembly::instantiate(new RNWebassemblyInstantiateParams{[a.iid() UTF8String], bufferSource, (size_t)data.length, a.stackSizeInBytes(), &rawFunctions, &rawFunctionScopes}));
 }
 
 - (NSArray<NSString *> *)invoke:(JS::NativeWebassembly::InvokeParams &)a {
@@ -27,7 +32,9 @@ RCT_EXPORT_MODULE()
     
     std::vector<std::string> res;
     
-    @(webassembly::invoke(new RNWebassemblyInvokeParams{[a.iid() UTF8String], [a.func() UTF8String], &args, &res}));
+    NSNumber* result = @(webassembly::invoke(new RNWebassemblyInvokeParams{[a.iid() UTF8String], [a.func() UTF8String], &args, &res}));
+    
+    if (result.intValue != 0) throw std::runtime_error("Failed to invoke.");
     
     NSMutableArray<NSString *> *array = [NSMutableArray arrayWithCapacity:res.size()];
     

--- a/src/NativeWebassembly.ts
+++ b/src/NativeWebassembly.ts
@@ -6,6 +6,7 @@ export type InstantiateParams = {
   readonly bufferSource: string;
   readonly stackSizeInBytes: number;
   readonly rawFunctions: readonly string[];
+  readonly rawFunctionScopes: readonly string[];
 };
 
 export type InvokeParams = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,11 +53,14 @@ export async function instantiate<Exports extends object>(
 
   const stackSizeInBytes = memory?.__initial ?? DEFAULT_STACK_SIZE_IN_BYTES;
 
+  const rawFunctions = Object.keys(importObject?.imports || {});
+
   const instanceResult = Webassembly.instantiate({
     iid,
     bufferSource: Buffer.from(bufferSource).toString('base64'),
     stackSizeInBytes,
-    rawFunctions: Object.keys(importObject?.imports || {}),
+    rawFunctions,
+    rawFunctionScopes: rawFunctions.map(() => '*'),
   });
 
   if (instanceResult !== 0)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,13 +33,16 @@ const DEFAULT_MEMORY = new Memory({
 
 export type Imports = Record<string, Function>;
 
-type ImportsMap = Omit<{
-  readonly [key: string]: Imports | WebAssemblyEnv;
-}, 'env'>;
+type ImportsMap = Omit<
+  {
+    readonly [key: string]: Imports | WebAssemblyEnv;
+  },
+  'env'
+>;
 
 export type WebAssemblyImportObject = ImportsMap & {
   readonly env?: WebAssemblyEnv;
-}
+};
 
 export type WebassemblyInstantiateResult<Exports extends object> = {
   readonly instance: WebassemblyInstance<Exports>;
@@ -50,14 +53,14 @@ type ScopedFunction = {
   readonly scope: string;
 };
 
-const getScopedFunctions = (importsMap: ImportsMap): readonly ScopedFunction[] => {
+const getScopedFunctions = (
+  importsMap: ImportsMap
+): readonly ScopedFunction[] => {
   if (!importsMap) return [];
 
-  return Object.entries(importsMap)
-    .flatMap(
-      ([scope, imports]) =>
-        Object.keys(imports).map(functionName => ({scope, functionName}))
-    );
+  return Object.entries(importsMap).flatMap(([scope, imports]) =>
+    Object.keys(imports).map((functionName) => ({ scope, functionName }))
+  );
 };
 
 // https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate
@@ -67,11 +70,8 @@ export async function instantiate<Exports extends object>(
 ): Promise<WebassemblyInstantiateResult<Exports>> {
   const iid = nanoid();
 
-  const importObject =  maybeImportObject || {};
-  const {
-    env: maybeEnv,
-    ...extras
-  } = importObject;
+  const importObject = maybeImportObject || {};
+  const { env: maybeEnv, ...extras } = importObject;
 
   const memory = maybeEnv?.memory || DEFAULT_MEMORY;
 
@@ -79,8 +79,8 @@ export async function instantiate<Exports extends object>(
 
   const scopedFunctions = getScopedFunctions(extras);
 
-  const rawFunctions = scopedFunctions.map(({functionName}) => functionName);
-  const rawFunctionScopes = scopedFunctions.map(({scope}) => scope);
+  const rawFunctions = scopedFunctions.map(({ functionName }) => functionName);
+  const rawFunctionScopes = scopedFunctions.map(({ scope }) => scope);
 
   const instanceResult = Webassembly.instantiate({
     iid,


### PR DESCRIPTION
Previously, all raw functions passed into the WebAssembly runtime were expected to be defined under the `imports` key, and were allocated using universal scope. This PR adds namespace function support to correctly qualify the scope of raw functions.

- Fixed Typing for `env`'s `WebAssemblyEnv` in shared with neighbouring `ImportsMap`s.
- Compute function scope signatures in JS runtime and allocate these using C++ `instantiate` invocation.
- Updated `README.md`.
- Catch and propagate failed invocation results.