### PR TITLE
Improved callback interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const module = await WebAssembly.instantiate<{
 });
 ```
 
-Here, we declare an `exceptionHandler` as `imports` to the compiled module. Without declaring this required dependency, the module would fail to compile.
+Here, we declare an `exceptionHandler` as `runtime` imports to the compiled module. Without declaring this required dependency, the module would fail to compile.
 
 You can find a working implementation of this process in the [__Example App__](example/src/App.tsx).
 

--- a/cpp/m3_bind.c
+++ b/cpp/m3_bind.c
@@ -13,12 +13,12 @@
 u8  ConvertTypeCharToTypeId (char i_code)
 {
     switch (i_code) {
-    case 'v': return c_m3Type_none;
-    case 'i': return c_m3Type_i32;
-    case 'I': return c_m3Type_i64;
-    case 'f': return c_m3Type_f32;
-    case 'F': return c_m3Type_f64;
-    case '*': return c_m3Type_i32;
+        case 'v': return c_m3Type_none;
+        case 'i': return c_m3Type_i32;
+        case 'I': return c_m3Type_i64;
+        case 'f': return c_m3Type_f32;
+        case 'F': return c_m3Type_f64;
+        case '*': return c_m3Type_i32;
     }
     return c_m3Type_unknown;
 }

--- a/cpp/m3_bind.c
+++ b/cpp/m3_bind.c
@@ -23,7 +23,6 @@ u8  ConvertTypeCharToTypeId (char i_code)
     return c_m3Type_unknown;
 }
 
-
 M3Result  SignatureToFuncType  (IM3FuncType * o_functionType, ccstr_t i_signature)
 {
     IM3FuncType funcType = NULL;

--- a/cpp/m3_bind.h
+++ b/cpp/m3_bind.h
@@ -13,6 +13,7 @@
 d_m3BeginExternC
 
 u8          ConvertTypeCharToTypeId     (char i_code);
+char        ConvertTypeIdToTypeChar     (u8 type);
 M3Result    SignatureToFuncType         (IM3FuncType * o_functionType, ccstr_t i_signature);
 
 d_m3EndExternC

--- a/cpp/react-native-webassembly.cpp
+++ b/cpp/react-native-webassembly.cpp
@@ -140,11 +140,13 @@ namespace webassembly {
           
         const char* moduleName = f->import.moduleUtf8;
         const char* fieldName = f->import.fieldUtf8;
-        
-        std::string signature = transform_signature(f);
           
         // TODO: is this valid?
         if (!moduleName || !fieldName) continue;
+        
+        std::cout << "Linking " << moduleName << ":" << fieldName << "!" << "\n";
+          
+        std::string signature = transform_signature(f);
           
         M3FuncType * funcType = f->funcType;
           

--- a/cpp/react-native-webassembly.cpp
+++ b/cpp/react-native-webassembly.cpp
@@ -143,8 +143,6 @@ namespace webassembly {
           
         // TODO: is this valid?
         if (!moduleName || !fieldName) continue;
-        
-        std::cout << "Linking " << moduleName << ":" << fieldName << "!" << "\n";
           
         std::string signature = transform_signature(f);
           

--- a/cpp/react-native-webassembly.cpp
+++ b/cpp/react-native-webassembly.cpp
@@ -7,6 +7,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include "m3_info.h"
+#include "m3_env.h"
 #include "wasm3_cpp.h"
 
 int sum(int a, int b)
@@ -46,6 +48,29 @@ namespace webassembly {
       wasm3::module mod = env.parse_module(a->bufferSource, a->bufferSourceLength);
 
       runtime.load(mod);
+        
+      // First iterate the functions and manually determine interface.
+      // Then define the appropriate export.
+        
+      IM3Module io_module = mod.m_module.get();
+      
+      for (u32 i = 0; i < io_module->numFunctions; ++i)
+      {
+        const IM3Function f = & io_module->functions [i];
+          
+        const char* moduleName = f->import.moduleUtf8;
+        const char* fieldName = f->import.fieldUtf8;
+          
+        // TODO: is this valid?
+        if (!moduleName || !fieldName) continue;
+          
+        M3FuncType * funcType = f->funcType;
+          
+        const char* funcTypeSignature = SPrintFuncTypeSignature(funcType);
+          
+        std::cout << "function is " << moduleName << " " << fieldName << " " << funcTypeSignature << "\n";
+      }
+        
 
       std::vector<std::string>::value_type *rawFunctions = a->rawFunctions->data();
       std::vector<std::string>::value_type *rawFunctionScopes = a->rawFunctionScopes->data();

--- a/cpp/wasm3_cpp.h
+++ b/cpp/wasm3_cpp.h
@@ -277,6 +277,8 @@ namespace wasm3 {
           M3Result err = m3_CompileModule(m_module.get());
           detail::check_error(err);
         }
+        
+        std::shared_ptr<M3Module> m_module;
 
     protected:
         friend class environment;
@@ -313,7 +315,6 @@ namespace wasm3 {
         }
 
         std::shared_ptr<M3Environment> m_env;
-        std::shared_ptr<M3Module> m_module;
         bool m_loaded = false;
         std::vector<uint8_t> m_moduleRawData {};
     };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 
+import * as WebAssembly from 'react-native-webassembly';
+
 import { useWasmCircomRuntime, useWasmHelloWorld } from './hooks';
+import { fetchWasm } from './utils';
 
 export default function App() {
   const helloWorld = useWasmHelloWorld();
@@ -29,6 +32,15 @@ export default function App() {
 
     if (result !== 305) throw new Error('Failed to add.');
   }, [helloWorldResult]);
+
+  React.useEffect(() => void (async () => {
+    try {
+      /* complex */
+      await WebAssembly.instantiate(await fetchWasm('https://github.com/tact-lang/ton-wasm/raw/main/output/wasm/emulator-emscripten.wasm'), {});
+    } catch (e) {
+      console.error(e);
+    }
+  })(), []);
 
   return (
     <View style={styles.container}>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,8 +7,20 @@ export default function App() {
   const helloWorld = useWasmHelloWorld();
   const helloWorldResult =
     'result' in helloWorld ? helloWorld.result : undefined;
+  const helloWorldError =
+    'error' in helloWorld ? helloWorld.error : undefined;
 
-  const { calculateWTNSBin } = useWasmCircomRuntime();
+  const { calculateWTNSBin, error: circomError } = useWasmCircomRuntime();
+
+  React.useEffect(
+    () => void (helloWorldError && console.error(helloWorldError)),
+    [helloWorldError]
+  );
+
+  React.useEffect(
+    () => void (circomError && console.error(circomError)),
+    [circomError]
+  );
 
   React.useEffect(() => {
     if (!helloWorldResult) return;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,8 +10,7 @@ export default function App() {
   const helloWorld = useWasmHelloWorld();
   const helloWorldResult =
     'result' in helloWorld ? helloWorld.result : undefined;
-  const helloWorldError =
-    'error' in helloWorld ? helloWorld.error : undefined;
+  const helloWorldError = 'error' in helloWorld ? helloWorld.error : undefined;
 
   const { calculateWTNSBin, error: circomError } = useWasmCircomRuntime();
 
@@ -33,14 +32,23 @@ export default function App() {
     if (result !== 305) throw new Error('Failed to add.');
   }, [helloWorldResult]);
 
-  React.useEffect(() => void (async () => {
-    try {
-      /* complex */
-      await WebAssembly.instantiate(await fetchWasm('https://github.com/tact-lang/ton-wasm/raw/main/output/wasm/emulator-emscripten.wasm'), {});
-    } catch (e) {
-      console.error(e);
-    }
-  })(), []);
+  React.useEffect(
+    () =>
+      void (async () => {
+        try {
+          /* complex */
+          await WebAssembly.instantiate(
+            await fetchWasm(
+              'https://github.com/tact-lang/ton-wasm/raw/main/output/wasm/emulator-emscripten.wasm'
+            ),
+            {}
+          );
+        } catch (e) {
+          console.error(e);
+        }
+      })(),
+    []
+  );
 
   return (
     <View style={styles.container}>

--- a/example/src/hooks/useWasmCircomRuntime.ts
+++ b/example/src/hooks/useWasmCircomRuntime.ts
@@ -137,6 +137,7 @@ export function useWasmCircomRuntime() {
   );
 
   const result = 'result' in wasm ? wasm.result : undefined;
+  const error = 'error' in wasm ? wasm.error : undefined;
 
   const calculateWTNSBin = React.useCallback(
     (input: Circuits_01_Input, sanityCheck: number = 0) => {
@@ -229,5 +230,5 @@ export function useWasmCircomRuntime() {
     [result]
   );
 
-  return { calculateWTNSBin };
+  return { calculateWTNSBin, error };
 }

--- a/example/src/hooks/useWasmUri.ts
+++ b/example/src/hooks/useWasmUri.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import axios from 'axios';
 import * as WebAssembly from 'react-native-webassembly';
 import type { WebassemblyInstantiateResult } from 'react-native-webassembly';
+
+import { fetchWasm } from '../utils';
 
 type State<Exports extends object> = Readonly<
   | { loading: true }
@@ -21,16 +22,10 @@ export function useWasmUri<Exports extends object>(
     () =>
       void (async () => {
         try {
-          const { data: bufferSource } = await axios({
-            url: uri,
-            method: 'get',
-            responseType: 'arraybuffer',
-          });
-
           setState({
             loading: false,
             result: await WebAssembly.instantiate<Exports>(
-              bufferSource,
+              await fetchWasm(uri),
               importObject
             ),
           });

--- a/example/src/utils/fetchWasm.ts
+++ b/example/src/utils/fetchWasm.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export async function fetchWasm(uri: string) {
+  const { data: bufferSource } = await axios({
+    url: uri,
+    method: 'get',
+    responseType: 'arraybuffer',
+  });
+
+  return bufferSource;
+}

--- a/example/src/utils/index.ts
+++ b/example/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './fetchWasm';


### PR DESCRIPTION
After some experimentation, the naive callback implementation strategy was insufficient for arbitrary method declarations; it's clear that there's no specific standard in interface definitions, so we needed to adopt a more robust/flexible pattern for mapping to callback types.

- Removed fixed callback assertions.
- Auto-connect all interface definitions instead of having the caller manually debug upon instantiation.
- Improved clarity of error logs to help aid debugging.
- Fixed typo in the README which referred to a deprecated library linking format.
- Improved example.
  - Included complex wasm instantiation.
  - Extracted fetch logic.
  - Decoupled error handling. 