### PR TITLE
[android/app/build.gradle] fixed error related `namespace` 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,7 @@ def getExtOrIntegerDefault(name) {
 android {
   ndkVersion getExtOrDefault("ndkVersion")
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
+  namespace("com.webassembly")
 
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")


### PR DESCRIPTION
Added { namespace 'com.webassembly'} in build.gradle on android for resolve this issue:
 
<img width="999" alt="254588155-b7d4f328-50cc-49a3-800d-fd33b0093958" src="https://github.com/cawfree/react-native-webassembly/assets/109977975/79d08e8f-4b24-4218-b0d3-979299bda15e">

After test this error was solved.